### PR TITLE
🐛 prioritize correctness

### DIFF
--- a/packages/server/src/handlers/__tests__/check.spec.ts
+++ b/packages/server/src/handlers/__tests__/check.spec.ts
@@ -117,3 +117,16 @@ test("handleCheckWord: Valid, Unused Letter", () => {
     letterState: [2, 2, 2, 0, 0],
   });
 });
+
+test("handleCheckWord: Valid, Unused Letter", () => {
+  const handleCheckWord = createCheckHandler({
+    BANNED_WORD: "WRONG",
+    CORRECT_WORD: "CRANE",
+    ROW_LENGTH: "5",
+    REVISION: "1",
+  });
+  const output = handleCheckWord({ maybeWord: "ERASE", revision: 1 });
+  expect(output).toEqual({
+    letterState: [0, 2, 2, 0, 2],
+  });
+});

--- a/packages/server/src/handlers/__tests__/check.spec.ts
+++ b/packages/server/src/handlers/__tests__/check.spec.ts
@@ -88,7 +88,7 @@ test("handleCheckWord: Valid, Re-Arranged", () => {
   });
   const output = handleCheckWord({ maybeWord: "TIGHT", revision: 1 });
   expect(output).toEqual({
-    letterState: [1, 2, 2, 2, 2],
+    letterState: [0, 2, 2, 2, 2],
   });
 });
 

--- a/packages/server/src/handlers/__tests__/check.spec.ts
+++ b/packages/server/src/handlers/__tests__/check.spec.ts
@@ -104,3 +104,16 @@ test("handleCheckWord: Valid, Unused Letter", () => {
     letterState: [0, 2, 2, 2, 2],
   });
 });
+
+test("handleCheckWord: Valid, Unused Letter", () => {
+  const handleCheckWord = createCheckHandler({
+    BANNED_WORD: "WRONG",
+    CORRECT_WORD: "FRESH",
+    ROW_LENGTH: "5",
+    REVISION: "1",
+  });
+  const output = handleCheckWord({ maybeWord: "FREED", revision: 1 });
+  expect(output).toEqual({
+    letterState: [2, 2, 2, 0, 0],
+  });
+});

--- a/packages/server/src/handlers/check.ts
+++ b/packages/server/src/handlers/check.ts
@@ -65,14 +65,17 @@ export function createCheckHandler(config: EnvironmentLike) {
 }
 
 function getLetterState(word: string, guess: string) {
-  return guess.split("").map((letter, letterIndex) => {
-    const exists = word.indexOf(letter) >= 0;
-    const correctLocation = word[letterIndex] === letter;
-    if (correctLocation) {
-      return 2;
-    } else if (exists) {
-      return 1;
+  const letterState = word.split("");
+  const guessLetters = guess.split("");
+  letterState.forEach((correctLetter, i) => {
+    if (correctLetter === guessLetters[i]) {
+      letterState[i] = "2";
+      return;
+    } else if (letterState.indexOf(guessLetters[i]) >= 0) {
+      letterState[i] = "1";
+      return;
     }
-    return 0;
+    letterState[i] = "0";
   });
+  return letterState.map((l) => parseInt(l, 10) as LetterState);
 }

--- a/packages/server/src/handlers/types.ts
+++ b/packages/server/src/handlers/types.ts
@@ -14,8 +14,9 @@ type FOUND = 2;
 type EXISTS = 1;
 type NOT_FOUND = 0;
 
+export type LetterState = FOUND | EXISTS | NOT_FOUND;
 export type CheckWordResponse = {
-  letterState: (FOUND | EXISTS | NOT_FOUND)[];
+  letterState: LetterState[];
 };
 
 export type MetaConfig = Pick<Config, "rowLength" | "numRows" | "revision">;


### PR DESCRIPTION
If a letter has been located in the correct spot, do not show letter state for other occurrences unless there is another occurrence. 